### PR TITLE
feat: admin 사용자 작성이슈 클릭시 그 사용자 작성한 글 리스트로 가져오는..

### DIFF
--- a/src/main/java/com/ex/befinal/admin/controller/AdminController.java
+++ b/src/main/java/com/ex/befinal/admin/controller/AdminController.java
@@ -1,10 +1,12 @@
 package com.ex.befinal.admin.controller;
 
+import com.ex.befinal.admin.dto.AdminAllIssuesResponse;
 import com.ex.befinal.admin.dto.AdminIssuesResponse;
 import com.ex.befinal.admin.service.AdminService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -25,6 +27,18 @@ public class AdminController {
 
   private final AdminService adminService;
 
+  @Operation(summary = "모든 사용자 게시글 리스트 가져오기 API")
+  @GetMapping("/issues/all")
+  public ResponseEntity<Page<AdminAllIssuesResponse>> getAdminAllIssues(
+      @Parameter(description = "조회할 페이지 넘버(0부터 시작)", required = true)
+      @RequestParam("page") int page,
+      @Parameter(description = "가져올 데이터 갯수 단위", required = true)
+      @RequestParam("size") int size
+  ) {
+    PageRequest pageable = PageRequest.of(page, size);
+    Page<AdminAllIssuesResponse> responses = adminService.getAdminAllIssues(pageable);
+    return ResponseEntity.status(HttpStatus.OK).body(responses);
+  }
 
   @Operation(summary = "특정 사용자가 작성한 게시글 리스트 API")
   @GetMapping("/issues")
@@ -42,11 +56,11 @@ public class AdminController {
   }
 
   @Operation(summary = "관리자가 사용자 비/활성화 시키는 API")
-  @PatchMapping("/disable/{kakaoId}")
+  @PatchMapping("/disable/{nickname}")
   public ResponseEntity<Boolean> disableUser(
-      @PathVariable String kakaoId
+      @PathVariable String nickname
   ) {
-    boolean status = adminService.disableUser(kakaoId);
+    boolean status = adminService.disableUser(nickname);
     return ResponseEntity.status(HttpStatus.OK).body(status);
 
   }

--- a/src/main/java/com/ex/befinal/admin/controller/AdminController.java
+++ b/src/main/java/com/ex/befinal/admin/controller/AdminController.java
@@ -25,17 +25,8 @@ public class AdminController {
 
   private final AdminService adminService;
 
-//  @GetMapping
-//  public ResponseEntity<Void>
-//
-//  //kakaoId + 닉네임, 작성한 이슈수, 작성한 댓글 수, 상태, 가입일자
-//
-//  @GetMapping
-//  public ResponseEntity<Void>
-//
-//  //작성한 이슈목록으로 이동
 
-  @Operation(summary = "사용자가 작성한 게시글 가져오는 API")
+  @Operation(summary = "특정 사용자가 작성한 게시글 리스트 API")
   @GetMapping("/issues")
   public ResponseEntity<Page<AdminIssuesResponse>> getAdminIssues(
       @Parameter(description = "사용자 닉네임", required = true)
@@ -47,9 +38,9 @@ public class AdminController {
   ) {
     PageRequest pageable = PageRequest.of(page, size);
     Page<AdminIssuesResponse> responses = adminService.getAdminUserIssues(pageable, nickname);
-    return ResponseEntity.status(HttpStatus.OK).build();
+    return ResponseEntity.status(HttpStatus.OK).body(responses);
   }
-//게시시간 타이틀
+
   @Operation(summary = "관리자가 사용자 비/활성화 시키는 API")
   @PatchMapping("/disable/{kakaoId}")
   public ResponseEntity<Boolean> disableUser(

--- a/src/main/java/com/ex/befinal/admin/dto/AdminAllIssuesResponse.java
+++ b/src/main/java/com/ex/befinal/admin/dto/AdminAllIssuesResponse.java
@@ -1,0 +1,11 @@
+package com.ex.befinal.admin.dto;
+
+import java.util.Date;
+
+public record AdminAllIssuesResponse(
+    SimpleUser simpleUser,
+    Long issuesCount,
+    Long commentCount
+
+) {
+}

--- a/src/main/java/com/ex/befinal/admin/dto/AdminIssuesResponse.java
+++ b/src/main/java/com/ex/befinal/admin/dto/AdminIssuesResponse.java
@@ -3,6 +3,7 @@ package com.ex.befinal.admin.dto;
 import java.util.Date;
 
 public record AdminIssuesResponse(
+    Long id,
     String title,
     Date createdAt
 ) {

--- a/src/main/java/com/ex/befinal/admin/dto/SimpleUser.java
+++ b/src/main/java/com/ex/befinal/admin/dto/SimpleUser.java
@@ -1,0 +1,10 @@
+package com.ex.befinal.admin.dto;
+
+import java.util.Date;
+
+public record SimpleUser(
+    String nickname,
+    boolean userEnable,
+    Date userCreatedAt
+) {
+}

--- a/src/main/java/com/ex/befinal/admin/service/AdminService.java
+++ b/src/main/java/com/ex/befinal/admin/service/AdminService.java
@@ -1,13 +1,18 @@
 package com.ex.befinal.admin.service;
 
+import com.ex.befinal.admin.dto.AdminAllIssuesResponse;
 import com.ex.befinal.admin.dto.AdminIssuesResponse;
+import com.ex.befinal.admin.dto.SimpleUser;
 import com.ex.befinal.global.exception.GlobalException;
 import com.ex.befinal.models.User;
+import com.ex.befinal.repository.JpaCommentRepository;
+import com.ex.befinal.repository.JpaPostRepository;
 import com.ex.befinal.repository.PostDslRepository;
 import com.ex.befinal.user.repository.UserDslRepository;
 import com.ex.befinal.user.repository.UserJpaRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -15,12 +20,14 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AdminService {
 
   private final UserJpaRepository userJpaRepository;
   private final UserDslRepository userDslRepository;
   private final PostDslRepository postDslRepository;
-
+  private final JpaCommentRepository commentRepository;
+  private final JpaPostRepository postRepository;
   public Page<AdminIssuesResponse> getAdminUserIssues(
       PageRequest pageable, String nickname) {
     Long userId = userDslRepository.findByUserNickname(nickname)
@@ -32,7 +39,7 @@ public class AdminService {
 
 
   public boolean disableUser(String kakaoId) {
-    User user = userJpaRepository.findByKakaoId(kakaoId)
+    User user = userJpaRepository.findByNickName(kakaoId)
         .orElseThrow(GlobalException.NOT_FOUND::create);
     if (user.getEnable()) {
       user.setEnable(false);
@@ -43,5 +50,26 @@ public class AdminService {
     userJpaRepository.save(user);
     return user.getEnable();
 
+  }
+
+  public Page<AdminAllIssuesResponse> getAdminAllIssues(PageRequest pageable) {
+    List<Long> userIds = userDslRepository.getAllIds(pageable);
+
+    log.info("유저 아이디= {}", userIds);
+    List<AdminAllIssuesResponse> issuesResponses = userIds.stream()
+        .map(this::getPostDetails)
+        .toList();
+
+    return new PageImpl<>(issuesResponses);
+  }
+
+  private AdminAllIssuesResponse getPostDetails(Long id) {
+    Long commentCnt = commentRepository.countByUser_Id(id)
+        .orElse(0L);
+    Long postCnt = postRepository.countByUser_Id(id)
+        .orElse(0L);
+    SimpleUser simpleUser = userDslRepository.findUserById(id)
+        .orElseThrow(GlobalException.NOT_FOUND::create);
+    return new AdminAllIssuesResponse(simpleUser, postCnt, commentCnt);
   }
 }

--- a/src/main/java/com/ex/befinal/admin/service/AdminService.java
+++ b/src/main/java/com/ex/befinal/admin/service/AdminService.java
@@ -3,9 +3,13 @@ package com.ex.befinal.admin.service;
 import com.ex.befinal.admin.dto.AdminIssuesResponse;
 import com.ex.befinal.global.exception.GlobalException;
 import com.ex.befinal.models.User;
+import com.ex.befinal.repository.PostDslRepository;
+import com.ex.befinal.user.repository.UserDslRepository;
 import com.ex.befinal.user.repository.UserJpaRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
@@ -14,10 +18,16 @@ import org.springframework.stereotype.Service;
 public class AdminService {
 
   private final UserJpaRepository userJpaRepository;
+  private final UserDslRepository userDslRepository;
+  private final PostDslRepository postDslRepository;
 
   public Page<AdminIssuesResponse> getAdminUserIssues(
       PageRequest pageable, String nickname) {
-    return null;
+    Long userId = userDslRepository.findByUserNickname(nickname)
+        .orElseThrow(GlobalException.NOT_FOUND::create);
+    List<AdminIssuesResponse> allByUserId = postDslRepository.findAllByUserId(userId, pageable);
+
+    return new PageImpl<>(allByUserId);
   }
 
 

--- a/src/main/java/com/ex/befinal/authentication/api/AuthApi.java
+++ b/src/main/java/com/ex/befinal/authentication/api/AuthApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,26 +28,17 @@ public class AuthApi {
   @GetMapping("/signin-url")
   public ResponseEntity<UrlJson> getSignInUrlApi() {
     UrlJson loginUrl = authService.getLoginUrl();
-    return ResponseEntity.ok(loginUrl);
+    return ResponseEntity.status(HttpStatus.OK).body(loginUrl);
   }
 
   @Operation(summary = "로그인 API", description = "OAuth 로그인시 인증 코드를 넘겨받은 후 첫 로그인 시 회원 가입")
   @GetMapping("/signin/{provider}")
-  public ResponseEntity<UserResponse> signInApi(
+  public ResponseEntity<SignInResponse> signInApi(
 
       @RequestParam String authCode,
-      @PathVariable String provider,
-      HttpServletResponse response
+      @PathVariable String provider
   ) {
     SignInResponse signIn = authService.signIn(provider, authCode);
-    UserResponse user = UserResponse.builder()
-        .id(signIn.user().id())
-        .kakaoId(signIn.user().kakaoId())
-        .role(signIn.user().role())
-        .nickName(signIn.user().nickName())
-        .createdAt(signIn.user().createdAt())
-        .provider(signIn.user().provider()).build();
-    response.setHeader("Authorization", "Bearer " + signIn.accessToken());
-    return ResponseEntity.ok(user);
+    return ResponseEntity.status(HttpStatus.OK).body(signIn);
   }
 }

--- a/src/main/java/com/ex/befinal/authentication/service/AuthService.java
+++ b/src/main/java/com/ex/befinal/authentication/service/AuthService.java
@@ -49,9 +49,6 @@ public class AuthService {
       throw new DisabledException("비활성화된 회원입니다. 관리자에게 문의하세요.");
     }
     String accessToken = jwtTokenProvider.createAccessToken(user.getNickName());
-    String nickName = jwtTokenProvider.getNickName(accessToken);
-    log.info("별명이다"+ nickName);
-
     UserResponse userResponse =
         new UserResponse(
             user.getId(),

--- a/src/main/java/com/ex/befinal/authentication/service/TokenManager.java
+++ b/src/main/java/com/ex/befinal/authentication/service/TokenManager.java
@@ -1,0 +1,43 @@
+package com.ex.befinal.authentication.service;
+
+import com.ex.befinal.authentication.dto.CustomUserDetails;
+import com.ex.befinal.models.User;
+import com.ex.befinal.user.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class TokenManager {
+
+  private final UserJpaRepository userJpaRepository;
+
+  private Authentication getAuthentication() {
+    return SecurityContextHolder.getContext().getAuthentication();
+  }
+
+  public String getNickname() {
+    return getDetails().getUsername();
+  }
+
+  public User getUser() {
+    return getDetails().getUser();
+  }
+
+  public String getKakaoId() {
+    return getDetails().getPassword();
+  }
+
+  public Long getId() {
+    return getUser().getId();
+  }
+
+  private CustomUserDetails getDetails() {
+    return (CustomUserDetails) getAuthentication().getPrincipal();
+  }
+}

--- a/src/main/java/com/ex/befinal/global/config/SecurityConfig.java
+++ b/src/main/java/com/ex/befinal/global/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
             .requestMatchers(
                 "/swagger-ui/**", "/docs/**",
                 "/api-docs/**", "/auth/**").permitAll()
-            .requestMatchers("/admin/**")
+            .requestMatchers("/admin/**", "/user/**")
             .authenticated())
         .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
             UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/ex/befinal/repository/JpaCommentRepository.java
+++ b/src/main/java/com/ex/befinal/repository/JpaCommentRepository.java
@@ -1,6 +1,6 @@
 package com.ex.befinal.repository;
 
-import com.ex.befinal.models.Post;
+import com.ex.befinal.models.Comment;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,8 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface JpaPostRepository extends JpaRepository<Post, Long> {
-
+public interface JpaCommentRepository extends JpaRepository<Comment, Long> {
 
   Optional<Long> countByUser_Id(Long userId);
 }

--- a/src/main/java/com/ex/befinal/repository/JpaPostRepository.java
+++ b/src/main/java/com/ex/befinal/repository/JpaPostRepository.java
@@ -1,0 +1,9 @@
+package com.ex.befinal.repository;
+
+import com.ex.befinal.models.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaPostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/ex/befinal/repository/PostDslRepository.java
+++ b/src/main/java/com/ex/befinal/repository/PostDslRepository.java
@@ -1,0 +1,44 @@
+package com.ex.befinal.repository;
+
+import static com.ex.befinal.models.QPost.post;
+
+import com.ex.befinal.admin.dto.AdminIssuesResponse;
+import com.ex.befinal.models.Post;
+import com.querydsl.core.QueryFactory;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PostDslRepository {
+  private final JPAQueryFactory queryFactory;
+
+  public List<AdminIssuesResponse> findAllByUserId(
+      Long userId,
+      Pageable pageable
+  ) {
+    return queryFactory
+        .select(Projections.constructor(AdminIssuesResponse.class,
+                post.id,
+                post.title,
+                post.createdAt))
+        .from(post)
+        .where(post.user.id.eq(userId))
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+  }
+
+
+
+}

--- a/src/main/java/com/ex/befinal/repository/PostDslRepository.java
+++ b/src/main/java/com/ex/befinal/repository/PostDslRepository.java
@@ -2,6 +2,7 @@ package com.ex.befinal.repository;
 
 import static com.ex.befinal.models.QPost.post;
 
+import com.ex.befinal.admin.dto.AdminAllIssuesResponse;
 import com.ex.befinal.admin.dto.AdminIssuesResponse;
 import com.ex.befinal.models.Post;
 import com.querydsl.core.QueryFactory;
@@ -38,7 +39,6 @@ public class PostDslRepository {
         .limit(pageable.getPageSize())
         .fetch();
   }
-
 
 
 }

--- a/src/main/java/com/ex/befinal/user/api/UserApi.java
+++ b/src/main/java/com/ex/befinal/user/api/UserApi.java
@@ -1,0 +1,35 @@
+package com.ex.befinal.user.api;
+
+import com.ex.befinal.authentication.dto.CustomUserDetails;
+import com.ex.befinal.authentication.service.TokenManager;
+import com.ex.befinal.user.domain.UserProfile;
+import com.ex.befinal.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.antlr.v4.runtime.Token;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserApi {
+
+
+  private final UserService userService;
+
+  @Operation(summary = "본인 댓글 이슈 개수 가져오기 API")
+  @GetMapping("/profile")
+  public ResponseEntity<UserProfile> nickNameAndCount() {
+    UserProfile userProfile = userService.getUserCount();
+    return ResponseEntity.status(HttpStatus.OK).body(userProfile);
+  }
+}

--- a/src/main/java/com/ex/befinal/user/api/UserApi.java
+++ b/src/main/java/com/ex/befinal/user/api/UserApi.java
@@ -6,6 +6,7 @@ import com.ex.befinal.user.domain.UserProfile;
 import com.ex.befinal.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.Token;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
+@Tag(name = "C. 유저 API")
 @RequestMapping("/user")
 public class UserApi {
 

--- a/src/main/java/com/ex/befinal/user/repository/UserDslRepository.java
+++ b/src/main/java/com/ex/befinal/user/repository/UserDslRepository.java
@@ -2,11 +2,15 @@ package com.ex.befinal.user.repository;
 
 import static com.ex.befinal.models.QUser.user;
 
+import com.ex.befinal.admin.dto.SimpleUser;
+import com.mysql.cj.x.protobuf.MysqlxCrud;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -22,6 +26,28 @@ public class UserDslRepository {
             .select(user.id)
             .from(user)
             .where(user.nickName.eq(nickname))
+            .fetchOne()
+    );
+  }
+
+  public List<Long> getAllIds(PageRequest pageable) {
+    return queryFactory
+        .select(user.id)
+        .from(user)
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+  }
+
+  public Optional<SimpleUser> findUserById(Long id) {
+    return Optional.ofNullable(
+        queryFactory
+            .select(Projections.constructor(SimpleUser.class,
+                user.nickName,
+                user.enable,
+                user.createAt))
+            .from(user)
+            .where(user.id.eq(id))
             .fetchOne()
     );
   }

--- a/src/main/java/com/ex/befinal/user/repository/UserDslRepository.java
+++ b/src/main/java/com/ex/befinal/user/repository/UserDslRepository.java
@@ -1,0 +1,28 @@
+package com.ex.befinal.user.repository;
+
+import static com.ex.befinal.models.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserDslRepository {
+  private final JPAQueryFactory queryFactory;
+
+  public Optional<Long> findByUserNickname(
+      String nickname
+  ) {
+    return Optional.ofNullable(
+        queryFactory
+            .select(user.id)
+            .from(user)
+            .where(user.nickName.eq(nickname))
+            .fetchOne()
+    );
+  }
+}

--- a/src/main/java/com/ex/befinal/user/service/UserService.java
+++ b/src/main/java/com/ex/befinal/user/service/UserService.java
@@ -1,0 +1,27 @@
+package com.ex.befinal.user.service;
+
+import com.ex.befinal.authentication.service.TokenManager;
+import com.ex.befinal.models.User;
+import com.ex.befinal.repository.JpaCommentRepository;
+import com.ex.befinal.repository.JpaPostRepository;
+import com.ex.befinal.user.domain.UserProfile;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+  private final TokenManager tokenManager;
+  private final JpaPostRepository postRepository;
+  private final JpaCommentRepository commentRepository;
+
+  public UserProfile getUserCount() {
+    User user = tokenManager.getUser();
+    Long postCount = postRepository.countByUser_Id(user.getId())
+            .orElse(0L);
+    Long commentCount = commentRepository.countByUser_Id(user.getId())
+        .orElse(0L);
+    return new UserProfile(user.getNickName(), postCount, commentCount);
+  }
+}


### PR DESCRIPTION
## Type
- [x] Feature
- [ ] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
Implements [issue ISM-38](https://mcfinal.atlassian.net/browse/ISM-38)

## What & Why
![image](https://github.com/geezers-io/issuemap_api/assets/82084599/3f9cfaa6-323d-486d-911f-f30e8d88c6e8)

어드민이 작성한 이슈에 숫자를 클릭하면 사용자이름(닉네임)을 통해서 작성했던 글들을

![image](https://github.com/geezers-io/issuemap_api/assets/82084599/af583932-52a6-40ab-a344-0868cf858ad8)

이런 내부 내용을 가지고 페이지 네이션으로 가져오는 API 구현했습니다.

![image](https://github.com/geezers-io/issuemap_api/assets/82084599/023e160f-a03c-4a14-86e2-e6f14bdfe029)
---
## 추가 내용
![image](https://github.com/geezers-io/issuemap_api/assets/82084599/c6710e04-17d0-4272-8b54-fe1f9e6143de)
token을 통해서 클라이언트한테 요청을 받을 때 filter에서 SecurityContextHolder에 사용자 정보를 담게되는데 service단에서 사용자 정보를 빼서 쓸 수 있게 tokenmanager를 구현해봤습니다. 
"이렇게 해도 되는지 잘 모르겠네요..예전 session mananger에 영감을 받아 제작"
추가 적으로 은기님이 요청하신 스펙에 맞춰서 
![image](https://github.com/geezers-io/issuemap_api/assets/82084599/8e2b1650-6d9b-4dc6-90d9-bf8b9afed145)
구현했습니다.
## Checklist
- [x] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
